### PR TITLE
Apply Chefstyle to train-winrm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ Gemfile.local.lock
 *.gem
 .github/labels-in-terraform/.terraform
 Gemfile.lock
+.bundle

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
 # This is a Gemfile, which is used by bundler
 # to ensure a coherent set of gems is installed.
@@ -12,12 +12,12 @@ gemspec
 
 # Remaining group is only used for development.
 group :development do
-  gem 'bundler'
-  gem 'byebug'
-  gem 'm'
-  gem 'minitest'
-  gem 'mocha'
-  gem 'pry'
-  gem 'rake'
-  gem 'rubocop', '= 0.49.1' # Need to keep in sync with main InSpec project, so config files will work
+  gem "bundler"
+  gem "byebug"
+  gem "m"
+  gem "minitest"
+  gem "mocha"
+  gem "pry"
+  gem "rake"
+  gem "chefstyle"
 end

--- a/Rakefile
+++ b/Rakefile
@@ -6,22 +6,22 @@
 #------------------------------------------------------------------#
 
 # Do not run integration by default
-task default: %i(test:unit test:functional)
+task default: %i{test:unit test:functional}
 
 #------------------------------------------------------------------#
 #                    Test Runner Tasks
 #------------------------------------------------------------------#
-require 'rake/testtask'
+require "rake/testtask"
 
 namespace :test do
   {
-    unit: 'test/unit/*_test.rb',
-    integration: 'test/integration/*_test.rb',
-    functional: 'test/functional/*_test.rb',
+    unit: "test/unit/*_test.rb",
+    integration: "test/integration/*_test.rb",
+    functional: "test/functional/*_test.rb",
   }.each do |task_name, glob|
     Rake::TestTask.new(task_name) do |t|
-      t.libs.push 'lib'
-      t.libs.push 'test'
+      t.libs.push "lib"
+      t.libs.push "test"
       t.test_files = FileList[glob]
       t.verbose = true
       t.warning = false
@@ -32,19 +32,9 @@ end
 # #------------------------------------------------------------------#
 # #                    Code Style Tasks
 # #------------------------------------------------------------------#
-require 'rubocop/rake_task'
+require "chefstyle"
+require "rubocop/rake_task"
 
-RuboCop::RakeTask.new(:lint) do |t|
-  # Choices of rubocop rules to enforce are deeply personal.
-  # Here, we set things up so that your plugin will use the Bundler-installed
-  # train gem's copy of the Train project's rubocop.yml file (which
-  # is indeed packaged with the train gem).
-  if File.exist?('../train/.rubocop.yml')
-    train_rubocop_yml = '../train/.rubocop.yml'
-  else
-    require 'train/globals'
-    train_rubocop_yml = File.join(Train.src_root, '.rubocop.yml')
-  end
-
-  t.options = ['--display-cop-names', '--config', train_rubocop_yml]
+RuboCop::RakeTask.new(:lint) do |task|
+  task.options << "--display-cop-names"
 end

--- a/lib/train-winrm.rb
+++ b/lib/train-winrm.rb
@@ -12,9 +12,9 @@ libdir = File.dirname(__FILE__)
 $LOAD_PATH.unshift(libdir) unless $LOAD_PATH.include?(libdir)
 
 # It's traditonal to keep your gem version in a separate file, so CI can find it easier.
-require 'train-winrm/version'
+require "train-winrm/version"
 
 # A train plugin has three components: Transport, Connection, and (optionally) Platform.
 # Transport acts as the glue.
-require 'train-winrm/transport'
-require 'train-winrm/connection'
+require "train-winrm/transport"
+require "train-winrm/connection"

--- a/lib/train-winrm/connection.rb
+++ b/lib/train-winrm/connection.rb
@@ -33,8 +33,8 @@
 # * marshalling to / from JSON
 # You don't have to worry about most of this.
 
-require 'train'
-require 'train/plugins'
+require "train"
+require "train/plugins"
 
 module TrainPlugins
   module WinRM
@@ -61,7 +61,7 @@ module TrainPlugins
 
       # (see Base::Connection#login_command)
       def login_command
-        case RbConfig::CONFIG['host_os']
+        case RbConfig::CONFIG["host_os"]
         when /darwin/
           login_command_for_mac
         when /mswin|msys|mingw|cygwin|bccwin|wince|emc/
@@ -69,7 +69,7 @@ module TrainPlugins
         when /linux/
           login_command_for_linux
         else
-          fail ActionFailed,
+          raise ActionFailed,
                "Remote login not supported in #{self.class} " \
                "from host OS '#{RbConfig::CONFIG['host_os']}'."
         end
@@ -91,7 +91,7 @@ module TrainPlugins
         delay = 3
         session(
           retry_limit: @max_wait_until_ready / delay,
-          retry_delay: delay,
+          retry_delay: delay
         )
         run_command_via_connection(PING_COMMAND.dup)
       end
@@ -111,7 +111,7 @@ module TrainPlugins
       def run_command_via_connection(command, &data_handler)
         return if command.nil?
         logger.debug("[WinRM] #{self} (#{command})")
-        out = ''
+        out = ""
 
         response = session.run(command) do |stdout, _|
           yield(stdout) if data_handler && stdout
@@ -131,7 +131,7 @@ module TrainPlugins
         host = URI.parse(options[:endpoint]).host
         content = [
           "full address:s:#{host}:#{@rdp_port}",
-          'prompt for credentials:i:1',
+          "prompt for credentials:i:1",
           "username:s:#{options[:user]}",
         ].join("\n")
 
@@ -157,10 +157,10 @@ module TrainPlugins
       # @return [LoginCommand] a login command
       # @api private
       def login_command_for_linux
-        args  = %W(-u #{options[:user]})
-        args += %W(-p #{options[:pass]}) if options.key?(:pass)
-        args += %W(#{URI.parse(options[:endpoint]).host}:#{@rdp_port})
-        LoginCommand.new('rdesktop', args)
+        args  = %W{-u #{options[:user]}}
+        args += %W{-p #{options[:pass]}} if options.key?(:pass)
+        args += %W{#{URI.parse(options[:endpoint]).host}:#{@rdp_port}}
+        LoginCommand.new("rdesktop", args)
       end
 
       # Builds a `LoginCommand` for use by Mac-based platforms.
@@ -168,7 +168,7 @@ module TrainPlugins
       # @return [LoginCommand] a login command
       # @api private
       def login_command_for_mac
-        LoginCommand.new('open', rdp_doc(mac: true))
+        LoginCommand.new("open", rdp_doc(mac: true))
       end
 
       # Builds a `LoginCommand` for use by Windows-based platforms.
@@ -176,7 +176,7 @@ module TrainPlugins
       # @return [LoginCommand] a login command
       # @api private
       def login_command_for_windows
-        LoginCommand.new('mstsc', rdp_doc)
+        LoginCommand.new("mstsc", rdp_doc)
       end
 
       # Establishes a remote shell session, or establishes one when invoked
@@ -205,7 +205,7 @@ module TrainPlugins
       # @api private
       def to_s
         options_to_print = @options.clone
-        options_to_print[:password] = '<hidden>' if options_to_print.key?(:password)
+        options_to_print[:password] = "<hidden>" if options_to_print.key?(:password)
         "#{@username}@#{@hostname}<#{options_to_print.inspect}>"
       end
     end

--- a/lib/train-winrm/transport.rb
+++ b/lib/train-winrm/transport.rb
@@ -21,11 +21,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require 'rbconfig'
-require 'uri'
-require 'train'
-require 'train/errors'
-require 'train/plugins'
+require "rbconfig"
+require "uri"
+require "train"
+require "train/errors"
+require "train/plugins"
 
 # Train Plugins v1 are usually declared under the TrainPlugins namespace.
 # Each plugin has three components: Transport, Connection, and (optionally) Platform.
@@ -44,22 +44,22 @@ module TrainPlugins
     # @author Salim Afiune <salim@afiunemaya.com.mx>
     # @author Fletcher Nichol <fnichol@nichol.ca>
     class Transport < Train.plugin(1) # rubocop:disable Metrics/ClassLength
-      name 'winrm'
+      name "winrm"
 
-      require 'train-winrm/connection'
+      require "train-winrm/connection"
 
       # ref: https://github.com/winrb/winrm#transports
-      SUPPORTED_WINRM_TRANSPORTS = %i(negotiate ssl plaintext kerberos).freeze
+      SUPPORTED_WINRM_TRANSPORTS = %i{negotiate ssl plaintext kerberos}.freeze
 
       # common target configuration
       option :host, required: true
       option :port
-      option :user, default: 'administrator', required: true
+      option :user, default: "administrator", required: true
       option :password, nil
       option :winrm_transport, default: :negotiate
       option :winrm_disable_sspi, default: false
       option :winrm_basic_auth_only, default: false
-      option :path, default: '/wsman'
+      option :path, default: "/wsman"
       option :ssl, default: false
       option :self_signed, default: false
 
@@ -101,21 +101,21 @@ module TrainPlugins
         super(opts)
 
         # set scheme and port based on ssl activation
-        scheme = opts[:ssl] ? 'https' : 'http'
+        scheme = opts[:ssl] ? "https" : "http"
         port = opts[:port]
         port = (opts[:ssl] ? 5986 : 5985) if port.nil?
         winrm_transport = opts[:winrm_transport].to_sym
         unless SUPPORTED_WINRM_TRANSPORTS.include?(winrm_transport)
-          fail Train::ClientError, "Unsupported transport type: #{winrm_transport.inspect}"
+          raise Train::ClientError, "Unsupported transport type: #{winrm_transport.inspect}"
         end
 
         # remove leading '/'
-        path = (opts[:path] || '').sub(%r{^/+}, '')
+        path = (opts[:path] || "").sub(%r{^/+}, "")
 
         opts[:endpoint] = "#{scheme}://#{opts[:host]}:#{port}/#{path}"
       end
 
-      WINRM_FS_SPEC_VERSION = '~> 1.0'.freeze
+      WINRM_FS_SPEC_VERSION = "~> 1.0".freeze
 
       # Builds the hash of options needed by the Connection object on
       # construction.
@@ -125,23 +125,23 @@ module TrainPlugins
       # @api private
       def connection_options(opts)
         {
-          logger:                   logger,
-          transport:                opts[:winrm_transport].to_sym,
-          disable_sspi:             opts[:winrm_disable_sspi],
-          basic_auth_only:          opts[:winrm_basic_auth_only],
-          hostname:                 opts[:host],
-          endpoint:                 opts[:endpoint],
-          user:                     opts[:user],
-          password:                 opts[:password],
-          rdp_port:                 opts[:rdp_port],
-          connection_retries:       opts[:connection_retries],
-          connection_retry_sleep:   opts[:connection_retry_sleep],
-          max_wait_until_ready:     opts[:max_wait_until_ready],
+          logger: logger,
+          transport: opts[:winrm_transport].to_sym,
+          disable_sspi: opts[:winrm_disable_sspi],
+          basic_auth_only: opts[:winrm_basic_auth_only],
+          hostname: opts[:host],
+          endpoint: opts[:endpoint],
+          user: opts[:user],
+          password: opts[:password],
+          rdp_port: opts[:rdp_port],
+          connection_retries: opts[:connection_retries],
+          connection_retry_sleep: opts[:connection_retry_sleep],
+          max_wait_until_ready: opts[:max_wait_until_ready],
           no_ssl_peer_verification: opts[:self_signed],
-          realm:                    opts[:kerberos_realm],
-          service:                  opts[:kerberos_service],
-          ca_trust_file:            opts[:ca_trust_file],
-          ssl_peer_fingerprint:     opts[:ssl_peer_fingerprint],
+          realm: opts[:kerberos_realm],
+          service: opts[:kerberos_service],
+          ca_trust_file: opts[:ca_trust_file],
+          ssl_peer_fingerprint: opts[:ssl_peer_fingerprint],
         }
       end
 
@@ -164,24 +164,24 @@ module TrainPlugins
       # (see Base#load_needed_dependencies!)
       def load_needed_dependencies!
         spec_version = WINRM_FS_SPEC_VERSION.dup
-        logger.debug('winrm-fs requested,' \
+        logger.debug("winrm-fs requested," \
           " loading WinRM::FS gem (#{spec_version})")
-        gem 'winrm-fs', spec_version
-        first_load = require 'winrm-fs'
+        gem "winrm-fs", spec_version
+        first_load = require "winrm-fs"
         load_winrm_transport!
 
         if first_load
-          logger.debug('WinRM::FS library loaded')
+          logger.debug("WinRM::FS library loaded")
         else
-          logger.debug('WinRM::FS previously loaded')
+          logger.debug("WinRM::FS previously loaded")
         end
       rescue LoadError => e
         logger.fatal(
           "The `winrm-fs' gem is missing and must" \
-          ' be installed or cannot be properly activated. Run' \
+          " be installed or cannot be properly activated. Run" \
           " `gem install winrm-fs --version '#{spec_version}'`" \
-          ' or add the following to your Gemfile if you are using Bundler:' \
-          " `gem 'winrm-fs', '#{spec_version}'`.",
+          " or add the following to your Gemfile if you are using Bundler:" \
+          " `gem 'winrm-fs', '#{spec_version}'`."
         )
         raise Train::UserError,
               "Could not load or activate WinRM::FS (#{e.message})"
@@ -191,7 +191,7 @@ module TrainPlugins
       #
       # @api private
       def load_winrm_transport!
-        silence_warnings { require 'winrm-fs' }
+        silence_warnings { require "winrm-fs" }
       end
 
       # Return the last saved WinRM connection instance.

--- a/lib/train-winrm/version.rb
+++ b/lib/train-winrm/version.rb
@@ -5,6 +5,6 @@
 
 module TrainPlugins
   module WinRM
-    VERSION = '0.1.1'.freeze
+    VERSION = "0.1.1".freeze
   end
 end

--- a/train-winrm.gemspec
+++ b/train-winrm.gemspec
@@ -4,22 +4,22 @@
 
 # It is traditional in a gemspec to dynamically load the current version
 # from a file in the source tree.  The next three lines make that happen.
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'train-winrm/version'
+require "train-winrm/version"
 
 Gem::Specification.new do |spec|
   # Importantly, all Train plugins must be prefixed with `train-`
-  spec.name = 'train-winrm'
+  spec.name = "train-winrm"
 
   # It is polite to namespace your plugin under InspecPlugins::YourPluginInCamelCase
   spec.version       = TrainPlugins::WinRM::VERSION
-  spec.authors       = ['Chef InSpec Team']
-  spec.email         = ['inspec@chef.io']
-  spec.summary       = 'Windows WinRM API Transport for Train'
-  spec.description   = 'Allows applictaions using Train to speak to Windows using Remote Management; handles authentication, cacheing, and SDK dependency management.'
-  spec.homepage      = 'https://github.com/inspec/train-winrm'
-  spec.license       = 'Apache-2.0'
+  spec.authors       = ["Chef InSpec Team"]
+  spec.email         = ["inspec@chef.io"]
+  spec.summary       = "Windows WinRM API Transport for Train"
+  spec.description   = "Allows applictaions using Train to speak to Windows using Remote Management; handles authentication, cacheing, and SDK dependency management."
+  spec.homepage      = "https://github.com/inspec/train-winrm"
+  spec.license       = "Apache-2.0"
 
   # Though complicated-looking, this is pretty standard for a gemspec.
   # It just filters what will actually be packaged in the gem (leaving
@@ -27,9 +27,9 @@ Gem::Specification.new do |spec|
   spec.files = %w{
     README.md train-winrm.gemspec Gemfile
   } + Dir.glob(
-    'lib/**/*', File::FNM_DOTMATCH
+    "lib/**/*", File::FNM_DOTMATCH
   ).reject { |f| File.directory?(f) }
-  spec.require_paths = ['lib']
+  spec.require_paths = ["lib"]
 
   # If you rely on any other gems, list them here with any constraints.
   # This is how `inspec plugin install` is able to manage your dependencies.
@@ -39,7 +39,7 @@ Gem::Specification.new do |spec|
 
   # Do not list inspec as a dependency of a train plugin.
 
-  spec.add_dependency 'train', '~> 2.0'
-  spec.add_dependency 'winrm', '~> 2.0'
-  spec.add_dependency 'winrm-fs', '~> 1.0'
+  spec.add_dependency "train", "~> 2.0"
+  spec.add_dependency "winrm", "~> 2.0"
+  spec.add_dependency "winrm-fs", "~> 1.0"
 end


### PR DESCRIPTION
This sync's the train-winrm repo with the centralized chefstyle used by all Chef projects.