### PR TITLE
Update pin on train to v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Train plugins may be developed without a Chef InSpec installation.
 
 ### ChefDK Installation
 
-After June 2019, this plugin will be distributed with ChefDK; you do not need to install it separately.
+After August 2019, this plugin will be distributed with ChefDK; you do not need to install it separately.
 
 ### Manual Installation using `inspec plugin install`
 

--- a/train-winrm.gemspec
+++ b/train-winrm.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |spec|
 
   # Do not list inspec as a dependency of a train plugin.
 
-  spec.add_dependency "train", "~> 2.0"
+  spec.add_dependency "train", "~> 3.0"
   spec.add_dependency "winrm", "~> 2.0"
   spec.add_dependency "winrm-fs", "~> 1.0"
 end


### PR DESCRIPTION
Signed-off-by: Clinton Wolfe <clintoncwolfe@gmail.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

Updates dependencies on Train to be train 3. This is required so that a user of train will only obtain winrm functionality from one place - this plugin.

This PR must be merged sequentially - train v3 does not yet exist - hence DO NOT MERGE flag.

This must be merged after https://github.com/inspec/train/pull/448 is merged.

Motivation for this change: WinRM support requires gem dependencies that involve native extensions (and thus compilers). By separating out the winrm support into a plugin, we can continue to include it in the usual inspec distribution (inspec-bin or inspec gems) while removing the need for compilers from the -core gems (inspec-core-bin and inspec-core).

**

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
