### PR TITLE
Update expeditor config to publish rubygems on promote

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -13,16 +13,25 @@ github:
  delete_branch_on_merge: true
  minor_bump_labels:
   - "Version: Bump Minor"
+ major_bump_labels:
+  - "Version: Bump Major"
  version_tag_format: v{{version}}
  release_branch:
   - master
- 
+
 changelog:
  categories:
-  - "Type: New Resource": "New Resources"
   - "Type: New Feature": "New Features"
   - "Type: Enhancement": "Enhancements"
   - "Type: Bug": "Bug Fixes"
+
+rubygems:
+  - train-winrm
+
+promote:
+  actions:
+    - built_in:rollover_changelog
+    - built_in:publish_rubygems
 
 merge_actions:
  - built_in:bump_version:


### PR DESCRIPTION
Signed-off-by: Clinton Wolfe <clintoncwolfe@gmail.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

Looks like the expeditor config was missing a `promote` section entirely.
I'm leaving this set to include a patch version bump so we'll get a new (but pointless) build so we'll have something to promote.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
