### PR TITLE
Depend on train-core via the Gemfile, not train

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,9 @@ gemspec
 
 # Remaining group is only used for development.
 group :development do
+  # Depend on this here, not in the gemspec - to avoid having to have
+  # client applications induce circular dependencies
+  gem "train-core", "~> 3.0"
   gem "bundler"
   gem "byebug"
   gem "m"

--- a/train-winrm.gemspec
+++ b/train-winrm.gemspec
@@ -38,8 +38,9 @@ Gem::Specification.new do |spec|
   # them in Gemfile, not here.
 
   # Do not list inspec as a dependency of a train plugin.
-
-  spec.add_dependency "train", "~> 3.0"
+  # Train plugins should generally list train-core as
+  # their dependency, not train itself.
+  spec.add_dependency "train-core", "~> 3.0"
   spec.add_dependency "winrm", "~> 2.0"
   spec.add_dependency "winrm-fs", "~> 1.0"
 end

--- a/train-winrm.gemspec
+++ b/train-winrm.gemspec
@@ -38,9 +38,7 @@ Gem::Specification.new do |spec|
   # them in Gemfile, not here.
 
   # Do not list inspec as a dependency of a train plugin.
-  # Train plugins should generally list train-core as
-  # their dependency, not train itself.
-  spec.add_dependency "train-core", "~> 3.0"
+  # Do not list train or train-core as a dependency of a train plugin.
   spec.add_dependency "winrm", "~> 2.0"
   spec.add_dependency "winrm-fs", "~> 1.0"
 end


### PR DESCRIPTION
Signed-off-by: Clinton Wolfe <clintoncwolfe@gmail.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

It was pointed out that the train plugins should rely on train-core, not train, so that chef and others can pull train-winrm without pulling in other heavy dependencies.

This changes the dep to be on train-core, and moves the dep to the Gemfile, so cconsumers can do a sibling gem dependency on either train or train-core as they see fit.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
