### PR TITLE
expeditor: Add merge action to build a gem

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -26,12 +26,12 @@ changelog:
   - "Type: Bug": "Bug Fixes"
 
 rubygems:
-  - train-winrm
+ - train-winrm
 
 promote:
-  actions:
-    - built_in:rollover_changelog
-    - built_in:publish_rubygems
+ actions:
+  - built_in:rollover_changelog
+  - built_in:publish_rubygems
 
 merge_actions:
  - built_in:bump_version:
@@ -44,4 +44,6 @@ merge_actions:
     ignore_labels:
      - "Changelog: Skip Update"
      - "Expeditor: Skip All"
-
+ - built_in:build_gem:
+    only_if:
+     - built_in:bump_version


### PR DESCRIPTION
Signed-off-by: Clinton Wolfe <clintoncwolfe@gmail.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

We were missing a merge action to actually build the gem, which means that the gem did not exist to be published.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
