### PR TITLE
Limit the files we ship in the gem but include the LICENSE file

### DIFF
--- a/train-winrm.gemspec
+++ b/train-winrm.gemspec
@@ -24,12 +24,8 @@ Gem::Specification.new do |spec|
   # Though complicated-looking, this is pretty standard for a gemspec.
   # It just filters what will actually be packaged in the gem (leaving
   # out tests, etc)
-  spec.files = %w{
-    README.md train-winrm.gemspec Gemfile
-  } + Dir.glob(
-    "lib/**/*", File::FNM_DOTMATCH
-  ).reject { |f| File.directory?(f) }
   spec.require_paths = ["lib"]
+  spec.files = %w{LICENSE} + Dir.glob("lib/**/*", File::FNM_DOTMATCH).reject { |f| File.directory?(f) }
 
   # If you rely on any other gems, list them here with any constraints.
   # This is how `inspec plugin install` is able to manage your dependencies.


### PR DESCRIPTION
We need the license file to build omnibus packages so we can ensure we are compliant.  We don't need the gemspec and gemfile though. That's just extra space on disk.

Signed-off-by: Tim Smith <tsmith@chef.io>