### PR TITLE
Fixes for NameError: uninitialized constant TrainPlugins::WinRM::FS

### DIFF
--- a/lib/train-winrm/connection.rb
+++ b/lib/train-winrm/connection.rb
@@ -148,7 +148,7 @@ module TrainPlugins
         @file_manager ||= begin
           # Ensure @service is available:
           wait_until_ready
-          WinRM::FS::FileManager.new(@service)
+          ::WinRM::FS::FileManager.new(@service)
         end
       end
 


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
In order to load module`WinRM::FS` at top level so change it to `::WinRM::FS` https://github.com/inspec/train-winrm/blob/cc3957662a5a5cd522ac43b8d93abad5ddb8d47f/lib/train-winrm/connection.rb#L151
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
https://github.com/inspec/train-winrm/issues/17

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.

Signed-off-by: Vivek Singh <vivek.singh@msystechnologies.com>
