### PR TITLE
Fix default retry_limit

### DIFF
--- a/lib/train-winrm/connection.rb
+++ b/lib/train-winrm/connection.rb
@@ -189,10 +189,10 @@ module TrainPlugins
       # @api private
       def session(retry_options = {})
         @session ||= begin
-          opts = {
+          opts = retry_options.merge({
             retry_limit: @connection_retries.to_i,
             retry_delay: @connection_retry_sleep.to_i,
-          }.merge(retry_options)
+          })
 
           opts[:operation_timeout] = @operation_timeout unless @operation_timeout.nil?
           @service = ::WinRM::Connection.new(options.merge(opts))


### PR DESCRIPTION
Signed-off-by: Amol Shinde <amol.shinde@msystechnologies.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
retry_limit was not being overridden by connection_retries. So, the program was trying(mostly 200 times) to make a connection for [longer period](https://github.com/chef/chef/issues/8746#issuecomment-511970764) of time.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
Fixes #16 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
