### PR TITLE
Substitute require for require_relative

### DIFF
--- a/lib/train-winrm.rb
+++ b/lib/train-winrm.rb
@@ -12,9 +12,9 @@ libdir = File.dirname(__FILE__)
 $LOAD_PATH.unshift(libdir) unless $LOAD_PATH.include?(libdir)
 
 # It's traditonal to keep your gem version in a separate file, so CI can find it easier.
-require "train-winrm/version"
+require_relative "train-winrm/version"
 
 # A train plugin has three components: Transport, Connection, and (optionally) Platform.
 # Transport acts as the glue.
-require "train-winrm/transport"
-require "train-winrm/connection"
+require_relative "train-winrm/transport"
+require_relative "train-winrm/connection"

--- a/lib/train-winrm/transport.rb
+++ b/lib/train-winrm/transport.rb
@@ -46,7 +46,7 @@ module TrainPlugins
     class Transport < Train.plugin(1) # rubocop:disable Metrics/ClassLength
       name "winrm"
 
-      require "train-winrm/connection"
+      require_relative "connection"
 
       # ref: https://github.com/winrb/winrm#transports
       SUPPORTED_WINRM_TRANSPORTS = %i{negotiate ssl plaintext kerberos}.freeze


### PR DESCRIPTION
require_relative is significantly faster and should be used when available. See @lamont-granquist for the full story.

Signed-off-by: Tim Smith <tsmith@chef.io>