### PR TITLE
Remove redundant encoding comments

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 source "https://rubygems.org"
 
 # This is a Gemfile, which is used by bundler

--- a/lib/train-winrm/connection.rb
+++ b/lib/train-winrm/connection.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 #
 # Author:: Salim Afiune (<salim@afiunemaya.com.mx>)
 # Author:: Matt Wrock (<matt@mattwrock.com>)

--- a/lib/train-winrm/transport.rb
+++ b/lib/train-winrm/transport.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 #
 # Author:: Salim Afiune (<salim@afiunemaya.com.mx>)
 # Author:: Matt Wrock (<matt@mattwrock.com>)


### PR DESCRIPTION
utf-8 is the default in Ruby 2+

Signed-off-by: Tim Smith <tsmith@chef.io>