### PR TITLE
Optimize requires for non-omnibus installs

### DIFF
--- a/lib/train-winrm/transport.rb
+++ b/lib/train-winrm/transport.rb
@@ -21,8 +21,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require "rbconfig"
-require "uri"
+require "rbconfig" unless defined?(RbConfig)
+require "uri" unless defined?(URI)
 require "train"
 require "train/errors"
 require "train/plugins"


### PR DESCRIPTION
require is quite slow in Ruby and doing requires for things you've already required is also slow. We've used this simple hack in Chef to speed up our requires. In the omnibus installs we patch how rubygems works to make this somewhat pointless, but this will help non-omnibus installs

Signed-off-by: Tim Smith <tsmith@chef.io>