### PR TITLE
Add winrm-shell-type option and winrm elevated shell

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,4 +21,5 @@ group :development do
   gem "pry"
   gem "rake"
   gem "chefstyle"
+  gem "winrm-elevated"
 end

--- a/Rakefile
+++ b/Rakefile
@@ -42,9 +42,12 @@ namespace :test do
     env += "TRAIN_WINRM_TARGET=winrm://vagrant@127.0.0.1 "
     env += "TRAIN_WINRM_PASSWORD=vagrant "
 
-    Dir.glob("test/integration/*_test.rb").all? do |file|
-      sh "#{env} #{Gem.ruby} -I ./test/integration #{file}"
-    end || raise("Failures")
+    %w{powershell elevated}.each do |shell_type|
+      env += "TRAIN_WINRM_SHELL_TYPE=#{shell_type} "
+      Dir.glob("test/integration/*_test.rb").all? do |file|
+        sh "#{env} #{Gem.ruby} -I ./test/integration #{file}"
+      end || raise("Failures")
+    end
   end
 
   task :stop_vagrant do |_t|

--- a/lib/train-winrm/connection.rb
+++ b/lib/train-winrm/connection.rb
@@ -47,6 +47,7 @@ module TrainPlugins
         @connection_retry_sleep = @options.delete(:connection_retry_sleep)
         @max_wait_until_ready   = @options.delete(:max_wait_until_ready)
         @operation_timeout      = @options.delete(:operation_timeout)
+        @shell_type             = @options.delete(:winrm_shell_type)
       end
 
       # (see Base::Connection#close)
@@ -195,7 +196,7 @@ module TrainPlugins
           opts[:operation_timeout] = @operation_timeout unless @operation_timeout.nil?
           @service = ::WinRM::Connection.new(options.merge(opts))
           @service.logger = logger
-          @service.shell(:powershell)
+          @service.shell(@shell_type)
         end
       end
 

--- a/test/integration/winrm_test.rb
+++ b/test/integration/winrm_test.rb
@@ -18,7 +18,8 @@ describe "windows winrm command" do
       password: ENV["TRAIN_WINRM_PASSWORD"],
       ssl: ENV["TRAIN_WINRM_SSL"],
       self_signed: true,
-      logger: logger
+      logger: logger,
+      winrm_shell_type: ENV["TRAIN_WINRM_SHELL_TYPE"] || "powershell"
     )
 
     # initialize train

--- a/train-winrm.gemspec
+++ b/train-winrm.gemspec
@@ -4,7 +4,7 @@
 
 # It is traditional in a gemspec to dynamically load the current version
 # from a file in the source tree.  The next three lines make that happen.
-lib = File.expand_path("../lib", __FILE__)
+lib = File.expand_path("../lib", __FILE__) # rubocop:disable Style/ExpandPathArguments
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "train-winrm/version"
 
@@ -36,5 +36,6 @@ Gem::Specification.new do |spec|
   # Do not list inspec as a dependency of a train plugin.
   # Do not list train or train-core as a dependency of a train plugin.
   spec.add_dependency "winrm", "~> 2.0"
+  spec.add_dependency "winrm-elevated", "~> 1.2.2"
   spec.add_dependency "winrm-fs", "~> 1.0"
 end


### PR DESCRIPTION
Signed-off-by: Catriona Malone <cmalone@chef.io>


## Description
Adds in the option to choose a shell type (defaults to 'powershell', the original shell type). Added winrm-elevated so elevated shell can be used as a shell type.  See https://github.com/WinRb/winrm-elevated

If merged, a PR to inspec will follow to add winrm-shell-type as an option.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] I have read the **CONTRIBUTING** document.
