### PR TITLE
Allow timeout option for WinRM commands

### DIFF
--- a/test/unit/connection_test.rb
+++ b/test/unit/connection_test.rb
@@ -37,9 +37,9 @@ describe "winrm connection" do
       # We need to test run_command b/c run_command_via_connection is private.
       winrm.run_command("test") do |data|
         called = true
-        data.must_equal "testdata"
+        _(data).must_equal "testdata"
       end
-      called.must_equal true
+      _(called).must_equal true
     end
   end
 

--- a/test/unit/transport_test.rb
+++ b/test/unit/transport_test.rb
@@ -24,47 +24,47 @@ describe "winrm transport" do
     let(:winrm) { cls.new({ host: "dummy", logger: Logger.new(STDERR, level: :info) }) }
 
     it "can be instantiated (with valid config)" do
-      winrm.wont_be_nil
+      _(winrm).wont_be_nil
     end
 
     it "configures the host" do
-      winrm.options[:host].must_equal "dummy"
+      _(winrm.options[:host]).must_equal "dummy"
     end
 
     it "has default endpoint" do
-      winrm.options[:endpoint].must_be_nil
+      _(winrm.options[:endpoint]).must_be_nil
     end
 
     it "has default path set" do
-      winrm.options[:path].must_equal "/wsman"
+      _(winrm.options[:path]).must_equal "/wsman"
     end
 
     it "has default ssl set" do
-      winrm.options[:ssl].must_equal false
+      _(winrm.options[:ssl]).must_equal false
     end
 
     it "has default self_signed set" do
-      winrm.options[:self_signed].must_equal false
+      _(winrm.options[:self_signed]).must_equal false
     end
 
     it "has default rdp_port set" do
-      winrm.options[:rdp_port].must_equal 3389
+      _(winrm.options[:rdp_port]).must_equal 3389
     end
 
     it "has default winrm_transport set" do
-      winrm.options[:winrm_transport].must_equal :negotiate
+      _(winrm.options[:winrm_transport]).must_equal :negotiate
     end
 
     it "has default winrm_disable_sspi set" do
-      winrm.options[:winrm_disable_sspi].must_equal false
+      _(winrm.options[:winrm_disable_sspi]).must_equal false
     end
 
     it "has default winrm_basic_auth_only set" do
-      winrm.options[:winrm_basic_auth_only].must_equal false
+      _(winrm.options[:winrm_basic_auth_only]).must_equal false
     end
 
     it "has default user" do
-      winrm.options[:user].must_equal "administrator"
+      _(winrm.options[:user]).must_equal "administrator"
     end
   end
 
@@ -73,13 +73,13 @@ describe "winrm transport" do
     let(:connection) { winrm.connection }
     it "without ssl genrates uri" do
       conf[:host] = "dummy_host"
-      connection.uri.must_equal "winrm://administrator@http://dummy_host:5985/wsman:3389"
+      _(connection.uri).must_equal "winrm://administrator@http://dummy_host:5985/wsman:3389"
     end
 
     it "without ssl genrates uri" do
       conf[:ssl] = true
       conf[:host] = "dummy_host_ssl"
-      connection.uri.must_equal "winrm://administrator@https://dummy_host_ssl:5986/wsman:3389"
+      _(connection.uri).must_equal "winrm://administrator@https://dummy_host_ssl:5986/wsman:3389"
     end
   end
 
@@ -87,7 +87,7 @@ describe "winrm transport" do
     let(:winrm) { cls.new(conf) }
     it "raises an error when a non-supported winrm_transport is specificed" do
       conf[:winrm_transport] = "invalid"
-      proc { winrm.connection }.must_raise Train::ClientError
+      _(proc { winrm.connection }).must_raise Train::ClientError
     end
   end
 end


### PR DESCRIPTION
Allows end users (e.g. InSpec test coders) to specify a timeout for a potentially long running command.
If the timeout is reached, the command is expected to be terminated on the host and an exception is raised (a subsequent change to InSpec will handle this exception).
This complements recent changes to the base connection and ssh connection in train: https://github.com/inspec/train/pull/625

Tested with a variety of commands with and without the `timeout` option against Server 2019 and 2012R2 instances.

Signed-off-by: James Stocks <jstocks@chef.io>

<!--- Provide a short summary of your changes in the Title above -->

## Related Issue
https://github.com/inspec/inspec/issues/3772

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ X] I have read the **CONTRIBUTING** document.
