### PR TITLE
Add validation to winrm shell type option

### DIFF
--- a/lib/train-winrm/transport.rb
+++ b/lib/train-winrm/transport.rb
@@ -46,6 +46,7 @@ module TrainPlugins
 
       # ref: https://github.com/winrb/winrm#transports
       SUPPORTED_WINRM_TRANSPORTS = %i{negotiate ssl plaintext kerberos}.freeze
+      SUPPORTED_WINRM_SHELL_TYPES = %i{powershell elevated cmd}.freeze
 
       # common target configuration
       option :host, required: true
@@ -104,6 +105,11 @@ module TrainPlugins
         winrm_transport = opts[:winrm_transport].to_sym
         unless SUPPORTED_WINRM_TRANSPORTS.include?(winrm_transport)
           raise Train::ClientError, "Unsupported transport type: #{winrm_transport.inspect}"
+        end
+
+        winrm_shell_type = opts[:winrm_shell_type].to_sym
+        unless SUPPORTED_WINRM_SHELL_TYPES.include?(winrm_shell_type)
+          raise Train::ClientError, "Unsupported winrm shell type: #{winrm_shell_type.inspect}"
         end
 
         # remove leading '/'


### PR DESCRIPTION
Signed-off-by: Catriona Malone <cmalone@chef.io>

Added a check to make sure any option passed in is valid for winrm-shell-type.

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] I have read the **CONTRIBUTING** document.
