### PR TITLE
Updating expeditor configuration

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -16,7 +16,8 @@ github:
  major_bump_labels:
   - "Version: Bump Major"
  version_tag_format: v{{version}}
- release_branch:
+ 
+release_branches:
   - master
 
 changelog:
@@ -28,22 +29,25 @@ changelog:
 rubygems:
  - train-winrm
 
-promote:
- actions:
-  - built_in:rollover_changelog
-  - built_in:publish_rubygems
+subscriptions:
+  - workload: project_promoted:{{agent_id}}:*
+    actions:
+     - built_in:rollover_changelog
+     - built_in:publish_rubygems
 
-merge_actions:
- - built_in:bump_version:
-    ignore_labels:
-     - "Version: Skip Bump"
-     - "Expeditor: Skip All"
- - bash:.expeditor/update_version.sh:
-    only_if: built_in:bump_version
- - built_in:update_changelog:
-    ignore_labels:
-     - "Changelog: Skip Update"
-     - "Expeditor: Skip All"
- - built_in:build_gem:
-    only_if:
-     - built_in:bump_version
+subscriptions:
+  - workload: pull_request_merged:{{github_repo}}:{{release_branch}}:*
+    actions:
+      - built_in:bump_version:
+         ignore_labels:
+          - "Version: Skip Bump"
+          - "Expeditor: Skip All"
+      - bash:.expeditor/update_version.sh:
+         only_if: built_in:bump_version
+      - built_in:update_changelog:
+         ignore_labels:
+          - "Changelog: Skip Update"
+          - "Expeditor: Skip All"
+      - built_in:build_gem:
+         only_if:
+          - built_in:bump_version


### PR DESCRIPTION
Signed-off-by: jayashri garud <jgarud@msystechnologies.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
i) The merge_actions subscription shortcut has been deprecated. All subscriptions should be declared via the subscriptions block for clarity.
ii) Release branches are a first-class concept in Expeditor, and should be represented as such.
iii) The promote block has been deprecated. All actions should be declared via the subscriptions block for clarity.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
