### PR TITLE
Drop support for Ruby 3.0 

### DIFF
--- a/.expeditor/coverage.pipeline.yml
+++ b/.expeditor/coverage.pipeline.yml
@@ -9,11 +9,11 @@ expeditor:
 
 steps:
 
-  - label: coverage-ruby-3.0
+  - label: coverage-ruby-3.1
     command:
       - CI_ENABLE_COVERAGE=1 /workdir/.expeditor/buildkite/verify.sh
     expeditor:
       secrets: true
       executor:
         docker:
-          image: ruby:3.0
+          image: ruby:3.1

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -1,14 +1,6 @@
 ---
 steps:
 
-- label: run-tests-ruby-3.0
-  command:
-    - /workdir/.expeditor/buildkite/verify.sh
-  expeditor:
-    executor:
-      docker:
-        image: ruby:3.0
-
 - label: run-tests-ruby-3.1
   command:
     - /workdir/.expeditor/buildkite/verify.sh
@@ -16,16 +8,6 @@ steps:
     executor:
       docker:
         image: ruby:3.1
-
-- label: run-specs-ruby-3.0-windows
-  commands:
-   - .expeditor/buildkite/verify.ps1
-  expeditor:
-   executor:
-      docker:
-        host_os: windows
-        shell: ["powershell", "-Command"]
-        image: rubydistros/windows-2019:3.0
 
 - label: run-specs-ruby-3.1-windows
   commands:

--- a/train-winrm.gemspec
+++ b/train-winrm.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |spec|
   spec.description   = "Allows applictaions using Train to speak to Windows using Remote Management; handles authentication, cacheing, and SDK dependency management."
   spec.homepage      = "https://github.com/inspec/train-winrm"
   spec.license       = "Apache-2.0"
+  spec.required_ruby_version = Gem::Requirement.new(">= 3.1.0")
   # Though complicated-looking, this is pretty standard for a gemspec.
   # It just filters what will actually be packaged in the gem (leaving
   # out tests, etc)

--- a/train-winrm.gemspec
+++ b/train-winrm.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.description   = "Allows applictaions using Train to speak to Windows using Remote Management; handles authentication, cacheing, and SDK dependency management."
   spec.homepage      = "https://github.com/inspec/train-winrm"
   spec.license       = "Apache-2.0"
-
+  spec.required_ruby_version = Gem::Requirement.new(">= 3.1.0")
   # Though complicated-looking, this is pretty standard for a gemspec.
   # It just filters what will actually be packaged in the gem (leaving
   # out tests, etc)

--- a/train-winrm.gemspec
+++ b/train-winrm.gemspec
@@ -20,7 +20,6 @@ Gem::Specification.new do |spec|
   spec.description   = "Allows applictaions using Train to speak to Windows using Remote Management; handles authentication, cacheing, and SDK dependency management."
   spec.homepage      = "https://github.com/inspec/train-winrm"
   spec.license       = "Apache-2.0"
-  spec.required_ruby_version = Gem::Requirement.new(">= 3.1.0")
   # Though complicated-looking, this is pretty standard for a gemspec.
   # It just filters what will actually be packaged in the gem (leaving
   # out tests, etc)


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Dropped support for Ruby 3.0. The minimum Ruby version supported will be 3.1
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
