### PR TITLE
CHEF-20643, CHEF-21059, CHEF-21058, CHEF-23072 socks5h with kerberos support

### DIFF
--- a/lib/train-winrm/connection.rb
+++ b/lib/train-winrm/connection.rb
@@ -53,21 +53,8 @@ module TrainPlugins
 
         # SOCKS proxy patch for HTTPClient
         if @options[:socks_proxy]
-          require "socksify"
-          require "httpclient"
-
-          proxy_host, proxy_port = @options[:socks_proxy].split(":")
-          TCPSocket.socks_server = proxy_host
-          TCPSocket.socks_port   = proxy_port
-
-          HTTPClient::Session.class_eval do
-            unless method_defined?(:original_create_socket)
-              alias_method :original_create_socket, :create_socket
-              def create_socket(host, port, *args)
-                ::TCPSocket.new(host, port)
-              end
-            end
-          end
+          require_relative "socks_proxy_patch"
+          SocksProxyPatch.apply(@options[:socks_proxy])
         end
       end
 

--- a/lib/train-winrm/connection.rb
+++ b/lib/train-winrm/connection.rb
@@ -50,6 +50,25 @@ module TrainPlugins
         @max_wait_until_ready   = @options.delete(:max_wait_until_ready)
         @operation_timeout      = @options.delete(:operation_timeout)
         @shell_type             = @options.delete(:winrm_shell_type)
+
+        # SOCKS proxy patch for HTTPClient
+        if @options[:socks_proxy]
+          require "socksify"
+          require "httpclient"
+
+          proxy_host, proxy_port = @options[:socks_proxy].split(":")
+          TCPSocket.socks_server = proxy_host
+          TCPSocket.socks_port   = proxy_port
+
+          HTTPClient::Session.class_eval do
+            unless method_defined?(:original_create_socket)
+              alias_method :original_create_socket, :create_socket
+              def create_socket(host, port, *args)
+                ::TCPSocket.new(host, port)
+              end
+            end
+          end
+        end
       end
 
       # (see Base::Connection#close)

--- a/lib/train-winrm/socks_proxy_patch.rb
+++ b/lib/train-winrm/socks_proxy_patch.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+# Patches the `HTTPClient` and `TCPSocket` classes to use a SOCKS5H proxy.
+# This class modifies the behavior of `HTTPClient` to route HTTP requests
+# through a SOCKS proxy by overriding the socket creation method.
+# It also configures `TCPSocket` to use the specified SOCKS proxy server.
+
+class SocksProxyPatch
+  # Applies the SOCKS proxy settings to `HTTPClient` and `TCPSocket`.
+  #
+  # @param socks_proxy [String] The SOCKS proxy address in the format `host:port`.
+  # @example
+  #   SocksProxyPatch.apply("127.0.0.1:1080")
+  def self.apply(socks_proxy)
+    require "socksify"
+    require "httpclient"
+
+    # Extract the host and port from the SOCKS proxy address.
+    proxy_host, proxy_port = socks_proxy.split(":")
+    TCPSocket.socks_server = proxy_host
+    TCPSocket.socks_port   = proxy_port
+
+    # Patch the `HTTPClient::Session` class to use the SOCKS proxy.
+    HTTPClient::Session.class_eval do
+      unless method_defined?(:original_create_socket)
+        alias_method :original_create_socket, :create_socket
+
+        # Override the `create_socket` method to use `TCPSocket` with SOCKS proxy.
+        def create_socket(host, port, *args)
+          ::TCPSocket.new(host, port)
+        end
+      end
+    end
+  end
+end

--- a/lib/train-winrm/transport.rb
+++ b/lib/train-winrm/transport.rb
@@ -122,7 +122,9 @@ module TrainPlugins
           raise Train::ClientError, "Unsupported winrm shell type: #{winrm_shell_type.inspect}"
         end
 
-        # remove leading '/'
+        # Set scheme, port, endpoint
+        scheme = opts[:ssl] ? "https" : "http"
+        port = opts[:port] || (opts[:ssl] ? 5986 : 5985)
         path = (opts[:path] || "").sub(%r{^/+}, "")
 
         opts[:endpoint] = "#{scheme}://#{opts[:host]}:#{port}/#{path}"

--- a/lib/train-winrm/transport.rb
+++ b/lib/train-winrm/transport.rb
@@ -107,16 +107,17 @@ module TrainPlugins
       def validate_options(opts)
         super(opts)
 
-        # set scheme and port based on ssl activation
-        scheme = opts[:ssl] ? "https" : "http"
-        port = opts[:port]
-        port = (opts[:ssl] ? 5986 : 5985) if port.nil?
-        winrm_transport = opts[:winrm_transport].to_sym
+        # Normalize to symbols
+        opts[:winrm_transport] = opts[:winrm_transport].to_s.downcase.to_sym if opts[:winrm_transport]
+        opts[:winrm_shell_type] = opts[:winrm_shell_type].to_s.downcase.to_sym if opts[:winrm_shell_type]
+
+        winrm_transport = opts[:winrm_transport]
+        winrm_shell_type = opts[:winrm_shell_type]
+
         unless SUPPORTED_WINRM_TRANSPORTS.include?(winrm_transport)
           raise Train::ClientError, "Unsupported transport type: #{winrm_transport.inspect}"
         end
 
-        winrm_shell_type = opts[:winrm_shell_type].to_sym
         unless SUPPORTED_WINRM_SHELL_TYPES.include?(winrm_shell_type)
           raise Train::ClientError, "Unsupported winrm shell type: #{winrm_shell_type.inspect}"
         end
@@ -139,7 +140,7 @@ module TrainPlugins
       def connection_options(opts)
         {
           logger: logger,
-          transport: opts[:winrm_transport].to_sym,
+          transport: opts[:winrm_transport],
           disable_sspi: opts[:winrm_disable_sspi],
           basic_auth_only: opts[:winrm_basic_auth_only],
           hostname: opts[:host],

--- a/lib/train-winrm/transport.rb
+++ b/lib/train-winrm/transport.rb
@@ -128,6 +128,19 @@ module TrainPlugins
         path = (opts[:path] || "").sub(%r{^/+}, "")
 
         opts[:endpoint] = "#{scheme}://#{opts[:host]}:#{port}/#{path}"
+
+        # Auto-detect realm when not provided
+        if winrm_transport == :kerberos && opts[:kerberos_realm].nil?
+          begin
+            krb_realm = File.read("/etc/krb5.conf")[/default_realm\s*=\s*(\S+)/i, 1]
+            if krb_realm
+              opts[:kerberos_realm] = krb_realm
+              logger.debug("Kerberos realm auto-detected: #{krb_realm}")
+            end
+          rescue => e
+            logger.warn("Could not auto-detect Kerberos realm: #{e.message}")
+          end
+        end
       end
 
       WINRM_FS_SPEC_VERSION = ">= 1.3.7".freeze

--- a/lib/train-winrm/transport.rb
+++ b/lib/train-winrm/transport.rb
@@ -79,6 +79,11 @@ module TrainPlugins
       option :client_key , default: nil
       option :client_key_pass , default: nil
 
+      # new socks proxy options
+      option :socks_proxy, default: nil
+      option :socks_user, default: nil
+      option :socks_password, default: nil
+
       def initialize(opts)
         super(opts)
         load_needed_dependencies!

--- a/lib/train-winrm/transport.rb
+++ b/lib/train-winrm/transport.rb
@@ -175,6 +175,9 @@ module TrainPlugins
           client_cert: opts[:client_cert],
           client_key: opts[:client_key],
           key_pass: opts[:client_key_pass],
+          socks_proxy: opts[:socks_proxy],
+          socks_user: opts[:socks_user],
+          socks_password: opts[:socks_password],
         }
       end
 

--- a/test/unit/connection_test.rb
+++ b/test/unit/connection_test.rb
@@ -43,4 +43,23 @@ describe "winrm connection" do
     end
   end
 
+  describe "establishes successful kerberos auth winrm connection" do
+    let(:cls) { TrainPlugins::WinRM::Connection }
+    it "retrieves platform after kerberos connection" do
+      conf = {
+        hostname: "dummy",
+        transport: :kerberos,
+        password: "dummy",
+        logger: Logger.new(STDERR, level: :info),
+      }
+      conn = cls.new(conf)
+      # Simulate successful connection and platform detection
+      conn.stubs(:os).returns({ name: "windows", family: "windows", release: "10.0", arch: "x86_64" })
+      os = conn.os
+      _(os[:name]).must_equal "windows"
+      _(os[:family]).must_equal "windows"
+      _(os[:release]).must_equal "10.0"
+      _(os[:arch]).must_equal "x86_64"
+    end
+  end
 end

--- a/test/unit/transport_test.rb
+++ b/test/unit/transport_test.rb
@@ -90,4 +90,34 @@ describe "winrm transport" do
       _(proc { winrm.connection }).must_raise Train::ClientError
     end
   end
+
+  describe "kerberos realm defaults" do
+    let(:cls) { TrainPlugins::WinRM::Transport }
+    it "auto-detects kerberos realm if not provided" do
+      conf = {
+        host: "dummy",
+        winrm_transport: :kerberos,
+        password: "dummy",
+      }
+      File.stubs(:read).with("/etc/krb5.conf").returns("default_realm = EXAMPLE.COM")
+      winrm = cls.new(conf)
+      conn = winrm.connection
+      options = conn.instance_variable_get(:@options)
+      _(options[:realm]).must_equal "EXAMPLE.COM"
+    end
+  end
+
+  # test/unit/transport_test.rb
+  describe "winrm_transport parsing" do
+    let(:cls) { TrainPlugins::WinRM::Transport }
+    it "parses winrm_transport and does not default to negotiate" do
+      conf = {
+        host: "dummy",
+        winrm_transport: :kerberos,
+        password: "dummy",
+      }
+      winrm = cls.new(conf)
+      _(winrm.options[:winrm_transport]).must_equal :kerberos
+    end
+  end
 end

--- a/train-winrm.gemspec
+++ b/train-winrm.gemspec
@@ -41,4 +41,5 @@ Gem::Specification.new do |spec|
 
   # Gem dependency needed with Ruby 3.4 upgrade
   spec.add_dependency "syslog", "~> 0.1"
+  spec.add_dependency "socksify", "~> 1.7"
 end


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail, what problems does it solve? -->

This pull request introduces support for SOCKS5H proxy functionality in the `train-winrm` library, along with enhancements to Kerberos authentication and related testing. The most important changes include the addition of a `SocksProxyPatch` class, updates to the transport options, and integration tests to validate the new functionality.

### SOCKS5H Proxy Support:
* [`lib/train-winrm/connection.rb`](diffhunk://#diff-45bfe35aa96c6cf50e8b0884ca77c66be7b14483c32d53424af12cb5e5bb4e47R53-R58): Added logic to apply the `SocksProxyPatch` when the `:socks_proxy` option is provided during initialization.
* [`lib/train-winrm/socks_proxy_patch.rb`](diffhunk://#diff-5741b13ce295dd6ffd83012aa21b241f23998dacecbf5b0084e8c644956af471R1-R35): Introduced the `SocksProxyPatch` class to enable HTTP requests to route through a SOCKS proxy by patching `HTTPClient` and `TCPSocket`.
* [`lib/train-winrm/transport.rb`](diffhunk://#diff-6a568bb1d937a4ad0409197a183ecab07370790adf9c53e686debe5b356b9e1fR82-R86): Added new transport options (`:socks_proxy`, `:socks_user`, `:socks_password`) and updated the connection options to include these proxy settings. [[1]](diffhunk://#diff-6a568bb1d937a4ad0409197a183ecab07370790adf9c53e686debe5b356b9e1fR82-R86) [[2]](diffhunk://#diff-6a568bb1d937a4ad0409197a183ecab07370790adf9c53e686debe5b356b9e1fR178-R180)

### Kerberos Authentication Enhancements:
* [`lib/train-winrm/transport.rb`](diffhunk://#diff-6a568bb1d937a4ad0409197a183ecab07370790adf9c53e686debe5b356b9e1fL105-R143): Implemented auto-detection of the Kerberos realm from `/etc/krb5.conf` when not explicitly provided.
* [`test/unit/transport_test.rb`](diffhunk://#diff-fe74d4fb07d46067b3dbf75ab142402eac4cd21272f409043930f2b4ca2a03cbR93-R122): Added unit tests to verify Kerberos realm auto-detection and proper parsing of `winrm_transport`.

### Testing Enhancements:
* [`test/integration/winrm_test.rb`](diffhunk://#diff-c9614f3587e8c5ce7b78422e7cc50a917f793fff44fc2a17840e9d74576551bcR191-R263): Added integration tests to validate SOCKS5H proxy functionality, including scenarios for proxy credentials, unreachable proxies, and remote DNS resolution.
* [`test/unit/connection_test.rb`](diffhunk://#diff-41f4fad038aa347ee6f8ca4c27114b550d40cd463115b209b8d781d201761512R46-R64): Added a unit test to simulate successful Kerberos authentication and platform detection.

### Dependency Updates:
* [`train-winrm.gemspec`](diffhunk://#diff-d4233908eb80e022c3e008068fb54d2252a5c8b82eaf1d1f382650326ee15f9eR44): Added a new dependency on the `socksify` gem to support SOCKS proxy functionality.<!--- Provide a short summary of your changes in the Title above -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

https://progresssoftware.atlassian.net/browse/CHEF-23072
https://progresssoftware.atlassian.net/browse/CHEF-21058
https://progresssoftware.atlassian.net/browse/CHEF-21059

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New content (non-breaking change)
- [ ] Breaking change (a content change which would break existing functionality or processes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
