### PR TITLE
CHEF-25808 - standardize - remove_sla_from_readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,6 @@
 [![Gem Version](https://badge.fury.io/rb/train-winrm.svg)](https://badge.fury.io/rb/train-winrm)
 [![Build status](https://badge.buildkite.com/f293066ffe281ec41dc14fe941a2bafbdfa8110c0cd4024c88.svg?branch=master)](https://buildkite.com/chef-oss/inspec-train-winrm-master-verify)
 
-* **Project State: Active**
-* **Issues Response SLA: 3 business days**
-* **Pull Request Response SLA: 3 business days**
-
 This plugin allows applications that rely on Train to communicate with the WinRM API.  For example, you could use this to audit Windows Server 2016 machines.
 
 This plugin relies on the `chef-winrm` and `chef-winrm-fs` gems for implementation.


### PR DESCRIPTION
This pull request removes the oft-misleading Chef SLA text from the README.md file.

This action is being taken as part of the [2025 Repo Standardization Initiative](https://github.com/chef-boneyard/oss-repo-standardization-2025). 
As Progress Chef makes a best effort to respond to issues and pull requests in a timely manner, and prioritizes bugfixes and security updates on a customer-driven basis (which may span repos, or have no repo footprint at all), we no longer support the concept of a Service Level Agreement (SLA) on a repository-centric basis. For further details, see [Repo SLA Removal FAQ](https://github.com/chef-boneyard/oss-repo-standardization-2025/blob/main/messaging/sla-removal.md).